### PR TITLE
Load clients from storage and persist new ones

### DIFF
--- a/src/components/forms/ClientForm.jsx
+++ b/src/components/forms/ClientForm.jsx
@@ -70,9 +70,14 @@ const ClientForm = () => {
     setIsSubmitting(true);
     
     try {
-      // Here you would typically save the data to your backend
-      console.log('Form submitted:', formData);
-      
+      // Persist the client locally so it can be selected in evaluations
+      const storedClients = JSON.parse(localStorage.getItem('financialClients') || '[]');
+      const newClient = { id: Date.now(), ...formData };
+      storedClients.push(newClient);
+      localStorage.setItem('financialClients', JSON.stringify(storedClients));
+
+      console.log('Form submitted:', newClient);
+
       // Navigate to the dashboard or show success message
       navigate('/dashboard');
     } catch (error) {

--- a/src/components/forms/FinancialEvaluationForm.jsx
+++ b/src/components/forms/FinancialEvaluationForm.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import SafeIcon from '../../common/SafeIcon';
 import * as FiIcons from 'react-icons/fi';
@@ -6,16 +7,14 @@ import * as FiIcons from 'react-icons/fi';
 const { FiBarChart3, FiDollarSign, FiTrendingUp, FiSave, FiX, FiPieChart, FiUser } = FiIcons;
 
 const FinancialEvaluationForm = () => {
-  // Mock client data - in a real app this would come from an API or database
-  const [clients, setClients] = useState([
-    { id: 1, name: 'ABC Corp', industry: 'technology' },
-    { id: 2, name: 'Tech Innovations Inc', industry: 'technology' },
-    { id: 3, name: 'StartupXYZ', industry: 'technology' },
-    { id: 4, name: 'GreenTech Solutions', industry: 'manufacturing' },
-    { id: 5, name: 'Manufacturing Co', industry: 'manufacturing' },
-    { id: 6, name: 'Healthcare Systems Ltd', industry: 'healthcare' },
-    { id: 7, name: 'Finance Partners', industry: 'finance' }
-  ]);
+  const navigate = useNavigate();
+  const [clients, setClients] = useState([]);
+
+  // Load clients from localStorage
+  useEffect(() => {
+    const stored = JSON.parse(localStorage.getItem('financialClients') || '[]');
+    setClients(stored);
+  }, []);
 
   const [formData, setFormData] = useState({
     clientId: '',
@@ -56,6 +55,20 @@ const FinancialEvaluationForm = () => {
       }
     }
   }, [formData.clientId, clients]);
+
+  if (clients.length === 0) {
+    return (
+      <motion.div className="max-w-xl mx-auto py-8 text-center">
+        <p className="mb-4 text-gray-600">No clients found. Please add a client first.</p>
+        <button
+          onClick={() => navigate('/client-form')}
+          className="px-4 py-2 bg-blue-600 text-white rounded-lg"
+        >
+          Add Client
+        </button>
+      </motion.div>
+    );
+  }
 
   const handleChange = (e) => {
     const { name, value } = e.target;
@@ -98,6 +111,7 @@ const FinancialEvaluationForm = () => {
     const evaluations = JSON.parse(localStorage.getItem('financialEvaluations') || '[]');
     const newEvaluation = {
       id: evaluationId,
+      clientId: formData.clientId,
       ...formData,
       createdAt: new Date().toISOString()
     };


### PR DESCRIPTION
## Summary
- save client entries to `financialClients` in localStorage when submitting the client form
- load clients for the evaluation form from localStorage
- show a prompt if no clients exist yet
- store the `clientId` with evaluations for future reference

## Testing
- `npm run lint` *(fails: Invalid option '--ext')*

------
https://chatgpt.com/codex/tasks/task_e_68705733851083338db04706c5137c18