### PR TITLE
Reset form after saving client

### DIFF
--- a/src/components/forms/ClientForm.jsx
+++ b/src/components/forms/ClientForm.jsx
@@ -112,6 +112,7 @@ const ClientForm = () => {
 
       console.log('Form submitted:', newClient);
 
+      handleReset();
       navigate('/dashboard');
     } catch (error) {
       console.error('Error submitting form:', error);


### PR DESCRIPTION
## Summary
- clear form state after saving new client in ClientForm

## Testing
- `npm run lint` *(fails: Invalid option '--ext')*

------
https://chatgpt.com/codex/tasks/task_e_687062d18bdc8333a3e4714d585bc50f