### PR TITLE
Remove unused financial tabs

### DIFF
--- a/src/components/forms/FinancialEvaluationForm.jsx
+++ b/src/components/forms/FinancialEvaluationForm.jsx
@@ -36,11 +36,6 @@ const FinancialEvaluationForm = () => {
     clientName: '',
     evaluationDate: '',
     evaluationType: '',
-    revenue: '',
-    expenses: '',
-    assets: '',
-    liabilities: '',
-    cashFlow: '',
     monthlyIncome: '',
     monthlyExpenses: '',
     netIncome: '',
@@ -53,19 +48,10 @@ const FinancialEvaluationForm = () => {
     coverageNeeded: '',
     debtList: '',
     debtStrategy: '',
-    goals: '',
-    profitMargin: '',
-    debtToEquity: '',
-    currentRatio: '',
-    quickRatio: '',
-    riskAssessment: '',
-    creditScore: '',
-    industryBenchmark: '',
-    recommendations: '',
-    nextReviewDate: ''
+    goals: ''
   });
 
-  const [activeTab, setActiveTab] = useState('financial');
+  const [activeTab, setActiveTab] = useState('cashflow');
   const [errors, setErrors] = useState({});
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [selectedClient, setSelectedClient] = useState(null);
@@ -132,8 +118,6 @@ const FinancialEvaluationForm = () => {
     if (!formData.clientId) newErrors.clientId = 'Client is required';
     if (!formData.evaluationDate) newErrors.evaluationDate = 'Evaluation date is required';
     if (!formData.evaluationType) newErrors.evaluationType = 'Evaluation type is required';
-    if (!formData.revenue) newErrors.revenue = 'Revenue is required';
-    if (!formData.expenses) newErrors.expenses = 'Expenses are required';
     return newErrors;
   };
 
@@ -169,11 +153,6 @@ const FinancialEvaluationForm = () => {
       clientName: '',
       evaluationDate: '',
       evaluationType: '',
-      revenue: '',
-      expenses: '',
-      assets: '',
-      liabilities: '',
-      cashFlow: '',
       monthlyIncome: '',
       monthlyExpenses: '',
       netIncome: '',
@@ -186,24 +165,12 @@ const FinancialEvaluationForm = () => {
       coverageNeeded: '',
       debtList: '',
       debtStrategy: '',
-      goals: '',
-      profitMargin: '',
-      debtToEquity: '',
-      currentRatio: '',
-      quickRatio: '',
-      riskAssessment: '',
-      creditScore: '',
-      industryBenchmark: '',
-      recommendations: '',
-      nextReviewDate: ''
+      goals: ''
     });
     setSelectedClient(null);
   };
 
   const tabs = [
-    { id: 'financial', label: 'Financial Data', icon: FiDollarSign },
-    { id: 'ratios', label: 'Financial Ratios', icon: FiPieChart },
-    { id: 'analysis', label: 'Risk Analysis', icon: FiTrendingUp },
     { id: 'cashflow', label: 'Cashflow', icon: FiCreditCard },
     { id: 'balance', label: 'Balance Sheet', icon: FiFileText },
     { id: 'policies', label: 'Life Insurance Policies', icon: FiShield },
@@ -338,251 +305,6 @@ const FinancialEvaluationForm = () => {
             animate={{ opacity: 1, x: 0 }}
             transition={{ duration: 0.3 }}
           >
-            {activeTab === 'financial' && (
-              <div className="space-y-6">
-                <h2 className="text-lg font-semibold text-gray-900">Financial Data</h2>
-                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-2">
-                      Annual Revenue *
-                    </label>
-                    <div className="relative">
-                      <span className="absolute left-3 top-3.5 text-gray-400">$</span>
-                      <input
-                        type="number"
-                        name="revenue"
-                        value={formData.revenue}
-                        onChange={handleChange}
-                        className={`w-full pl-8 pr-4 py-3 border rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors ${
-                          errors.revenue ? 'border-red-500' : 'border-gray-300'
-                        }`}
-                        placeholder="0"
-                      />
-                    </div>
-                    {errors.revenue && (
-                      <p className="mt-1 text-sm text-red-600">{errors.revenue}</p>
-                    )}
-                  </div>
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-2">
-                      Annual Expenses *
-                    </label>
-                    <div className="relative">
-                      <span className="absolute left-3 top-3.5 text-gray-400">$</span>
-                      <input
-                        type="number"
-                        name="expenses"
-                        value={formData.expenses}
-                        onChange={handleChange}
-                        className={`w-full pl-8 pr-4 py-3 border rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors ${
-                          errors.expenses ? 'border-red-500' : 'border-gray-300'
-                        }`}
-                        placeholder="0"
-                      />
-                    </div>
-                    {errors.expenses && (
-                      <p className="mt-1 text-sm text-red-600">{errors.expenses}</p>
-                    )}
-                  </div>
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-2">
-                      Total Assets
-                    </label>
-                    <div className="relative">
-                      <span className="absolute left-3 top-3.5 text-gray-400">$</span>
-                      <input
-                        type="number"
-                        name="assets"
-                        value={formData.assets}
-                        onChange={handleChange}
-                        className="w-full pl-8 pr-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors"
-                        placeholder="0"
-                      />
-                    </div>
-                  </div>
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-2">
-                      Total Liabilities
-                    </label>
-                    <div className="relative">
-                      <span className="absolute left-3 top-3.5 text-gray-400">$</span>
-                      <input
-                        type="number"
-                        name="liabilities"
-                        value={formData.liabilities}
-                        onChange={handleChange}
-                        className="w-full pl-8 pr-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors"
-                        placeholder="0"
-                      />
-                    </div>
-                  </div>
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-2">
-                      Monthly Cash Flow
-                    </label>
-                    <div className="relative">
-                      <span className="absolute left-3 top-3.5 text-gray-400">$</span>
-                      <input
-                        type="number"
-                        name="cashFlow"
-                        value={formData.cashFlow}
-                        onChange={handleChange}
-                        className="w-full pl-8 pr-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors"
-                        placeholder="0"
-                      />
-                    </div>
-                  </div>
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-2">
-                      Credit Score
-                    </label>
-                    <input
-                      type="number"
-                      name="creditScore"
-                      value={formData.creditScore}
-                      onChange={handleChange}
-                      min="300"
-                      max="850"
-                      className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors"
-                      placeholder="300-850"
-                    />
-                  </div>
-                </div>
-              </div>
-            )}
-
-            {activeTab === 'ratios' && (
-              <div className="space-y-6">
-                <h2 className="text-lg font-semibold text-gray-900">Financial Ratios</h2>
-                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-2">
-                      Profit Margin (%)
-                    </label>
-                    <div className="relative">
-                      <input
-                        type="number"
-                        name="profitMargin"
-                        value={formData.profitMargin}
-                        onChange={handleChange}
-                        step="0.01"
-                        className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors"
-                        placeholder="0.00"
-                      />
-                      <span className="absolute right-3 top-3.5 text-gray-400">%</span>
-                    </div>
-                  </div>
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-2">
-                      Debt-to-Equity Ratio
-                    </label>
-                    <input
-                      type="number"
-                      name="debtToEquity"
-                      value={formData.debtToEquity}
-                      onChange={handleChange}
-                      step="0.01"
-                      className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors"
-                      placeholder="0.00"
-                    />
-                  </div>
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-2">
-                      Current Ratio
-                    </label>
-                    <input
-                      type="number"
-                      name="currentRatio"
-                      value={formData.currentRatio}
-                      onChange={handleChange}
-                      step="0.01"
-                      className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors"
-                      placeholder="0.00"
-                    />
-                  </div>
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-2">
-                      Quick Ratio
-                    </label>
-                    <input
-                      type="number"
-                      name="quickRatio"
-                      value={formData.quickRatio}
-                      onChange={handleChange}
-                      step="0.01"
-                      className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors"
-                      placeholder="0.00"
-                    />
-                  </div>
-                  <div className="md:col-span-2">
-                    <label className="block text-sm font-medium text-gray-700 mb-2">
-                      Industry Benchmark
-                    </label>
-                    <select
-                      name="industryBenchmark"
-                      value={formData.industryBenchmark}
-                      onChange={handleChange}
-                      className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors"
-                    >
-                      <option value="">Select benchmark</option>
-                      <option value="above">Above Industry Average</option>
-                      <option value="average">Industry Average</option>
-                      <option value="below">Below Industry Average</option>
-                    </select>
-                  </div>
-                </div>
-              </div>
-            )}
-
-            {activeTab === 'analysis' && (
-              <div className="space-y-6">
-                <h2 className="text-lg font-semibold text-gray-900">Risk Analysis</h2>
-                <div className="space-y-6">
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-2">
-                      Risk Assessment
-                    </label>
-                    <select
-                      name="riskAssessment"
-                      value={formData.riskAssessment}
-                      onChange={handleChange}
-                      className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors"
-                    >
-                      <option value="">Select risk level</option>
-                      <option value="low">Low Risk</option>
-                      <option value="medium">Medium Risk</option>
-                      <option value="high">High Risk</option>
-                      <option value="critical">Critical Risk</option>
-                    </select>
-                  </div>
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-2">
-                      Recommendations
-                    </label>
-                    <textarea
-                      name="recommendations"
-                      value={formData.recommendations}
-                      onChange={handleChange}
-                      rows={6}
-                      className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors"
-                      placeholder="Enter detailed recommendations and analysis..."
-                    />
-                  </div>
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-2">
-                      Next Review Date
-                    </label>
-                    <input
-                      type="date"
-                      name="nextReviewDate"
-                      value={formData.nextReviewDate}
-                      onChange={handleChange}
-                      className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors"
-                    />
-                  </div>
-                </div>
-              </div>
-            )}
 
             {activeTab === 'cashflow' && (
               <div className="space-y-6">

--- a/src/components/reports/PDFGenerator.jsx
+++ b/src/components/reports/PDFGenerator.jsx
@@ -71,11 +71,6 @@ const PDFGenerator = ({ onClose }) => {
       doc.text(`Client: ${selectedEvaluation.clientName}`, 10, 20);
       doc.text(`Type: ${selectedEvaluation.evaluationType}`, 10, 30);
       doc.text(`Date: ${new Date(selectedEvaluation.evaluationDate).toLocaleDateString()}`, 10, 40);
-      doc.text(`Revenue: $${Number(selectedEvaluation.revenue).toLocaleString()}`, 10, 50);
-      doc.text(`Expenses: $${Number(selectedEvaluation.expenses).toLocaleString()}`, 10, 60);
-      if (selectedEvaluation.profitMargin) {
-        doc.text(`Profit Margin: ${selectedEvaluation.profitMargin}%`, 10, 70);
-      }
     }
     doc.save(`${reportData.title || 'report'}.pdf`);
     return doc;
@@ -182,16 +177,7 @@ const PDFGenerator = ({ onClose }) => {
                     <p className="text-sm text-gray-600">
                       Date: {new Date(selectedEvaluation.evaluationDate).toLocaleDateString()}
                     </p>
-                    <div className="mt-2 grid grid-cols-2 gap-2">
-                      <div className="bg-white rounded p-2 text-sm">
-                        <span className="text-gray-600">Revenue:</span>
-                        <span className="ml-1 font-medium">${Number(selectedEvaluation.revenue).toLocaleString()}</span>
-                      </div>
-                      <div className="bg-white rounded p-2 text-sm">
-                        <span className="text-gray-600">Expenses:</span>
-                        <span className="ml-1 font-medium">${Number(selectedEvaluation.expenses).toLocaleString()}</span>
-                      </div>
-                    </div>
+                    <div className="mt-2" />
                   </div>
                 </div>
               </div>
@@ -357,28 +343,7 @@ const PDFGenerator = ({ onClose }) => {
                     </div>
                   )}
                   
-                  {reportData.includeRatios && (
-                    <div className="py-2">
-                      <div className="flex items-center text-green-600 mb-1">
-                        <SafeIcon icon={FiPieChart} className="mr-1" />
-                        <span className="text-xs">Financial Ratios</span>
-                      </div>
-                      <div className="grid grid-cols-2 gap-2 text-xs">
-                        {selectedEvaluation.profitMargin && (
-                          <div className="flex justify-between bg-gray-50 p-1 rounded">
-                            <span>Profit Margin:</span>
-                            <span>{selectedEvaluation.profitMargin}%</span>
-                          </div>
-                        )}
-                        {selectedEvaluation.currentRatio && (
-                          <div className="flex justify-between bg-gray-50 p-1 rounded">
-                            <span>Current Ratio:</span>
-                            <span>{selectedEvaluation.currentRatio}</span>
-                          </div>
-                        )}
-                      </div>
-                    </div>
-                  )}
+                  {reportData.includeRatios && null}
                   
                   {reportData.includeRecommendations && selectedEvaluation.recommendations && (
                     <div className="py-2">

--- a/src/components/reports/PDFReportViewer.jsx
+++ b/src/components/reports/PDFReportViewer.jsx
@@ -332,35 +332,7 @@ const PDFReportViewer = () => {
                 </div>
               </div>
               
-              {selectedReport.evaluation && (
-                <div className="mb-6">
-                  <h3 className="font-medium text-gray-900 mb-2">Financial Summary</h3>
-                  <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-                    <div className="bg-blue-50 p-3 rounded-lg">
-                      <p className="text-sm text-gray-500">Revenue</p>
-                      <p className="text-lg font-semibold">${Number(selectedReport.evaluation.revenue).toLocaleString()}</p>
-                    </div>
-                    <div className="bg-green-50 p-3 rounded-lg">
-                      <p className="text-sm text-gray-500">Expenses</p>
-                      <p className="text-lg font-semibold">${Number(selectedReport.evaluation.expenses).toLocaleString()}</p>
-                    </div>
-                    <div className="bg-purple-50 p-3 rounded-lg">
-                      <p className="text-sm text-gray-500">Profit</p>
-                      <p className="text-lg font-semibold">
-                        ${Number(selectedReport.evaluation.revenue - selectedReport.evaluation.expenses).toLocaleString()}
-                      </p>
-                    </div>
-                    <div className="bg-orange-50 p-3 rounded-lg">
-                      <p className="text-sm text-gray-500">Margin</p>
-                      <p className="text-lg font-semibold">
-                        {selectedReport.evaluation.profitMargin || 
-                          Math.round((selectedReport.evaluation.revenue - selectedReport.evaluation.expenses) / 
-                          selectedReport.evaluation.revenue * 100)}%
-                      </p>
-                    </div>
-                  </div>
-                </div>
-              )}
+              {selectedReport && null}
               
               <div className="text-center py-8 bg-gray-100 rounded-lg">
                 <SafeIcon icon={FiFileText} className="text-6xl text-gray-400 mx-auto mb-4" />


### PR DESCRIPTION
## Summary
- trim form initialization and tabs
- drop unused financial/ratio/analysis sections
- adjust PDF components to handle removed fields

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68706e125de883339ac8a5d298255ce4